### PR TITLE
comment out imports of encounter fields to avoid linting errors

### DIFF
--- a/vim-canvas-demo-app-react/src/components/encounter-content/index.tsx
+++ b/vim-canvas-demo-app-react/src/components/encounter-content/index.tsx
@@ -15,13 +15,13 @@ import {
   EntityFieldTitle,
   EntitySectionTitle,
 } from "../ui/entityContent";
-import { EncounterAssessment } from "./Assessment";
+// import { EncounterAssessment } from "./Assessment";
 import { EncounterBasicInformation } from "./BasicInformation";
 import { FormInputs, useNotesForm } from "./form";
-import { EncounterObjective } from "./Objective";
-import { EncounterPI } from "./PatientInstructions";
-import { EncounterPlan } from "./Plan";
-import { EncounterSubjective } from "./Subjective";
+// import { EncounterObjective } from "./Objective";
+// import { EncounterPI } from "./PatientInstructions";
+// import { EncounterPlan } from "./Plan";
+// import { EncounterSubjective } from "./Subjective";
 import { ScribeAIIntegration } from "../scribeai/ScribeAIIntegration";
 
 export const EncounterContent = () => {


### PR DESCRIPTION
encounter-content/index.tsx
- comment out encounter form fields as they were causing lint errors for unused imports